### PR TITLE
Implement `HashBag::difference(&self, other: &HashBag)`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -716,14 +716,13 @@ where
     /// let a: HashBag<_> = [1, 2, 3, 3].iter().cloned().collect();
     /// let b: HashBag<_> = [2, 3].iter().cloned().collect();
     /// let expected: HashSet<_> = HashSet::from_iter([(&1, 1), (&3, 1)]);
-    /// let actual: HashSet<_> = a.difference(&b).collect();
+    /// let actual: HashSet<_> = a.subtract(&b).collect();
     /// assert_eq!(expected, actual);
     /// ```
-    pub fn difference<'a>(&'a self, other: &'a HashBag<T, S>) -> Difference<'a, T, S> {
-        Difference {
+    pub fn subtract<'a>(&'a self, other: &'a HashBag<T, S>) -> Subtract<'a, T, S> {
+        Subtract {
             items: self.items.iter(),
             other,
-            upper_bound: self.count,
         }
     }
 
@@ -1135,29 +1134,26 @@ impl<'a, T> Iterator for Drain<'a, T> {
     }
 }
 
-/// This `struct` is created by [`HashBag::difference`].
+/// This `struct` is created by [`HashBag::subtract`].
 /// See its documentation for more.
-pub struct Difference<'a, T, S = RandomState> {
+pub struct Subtract<'a, T, S = RandomState> {
     /// An iterator over `self` items
     items: IterInner<'a, T>,
 
     /// The bag with entries we DO NOT want to return
     other: &'a HashBag<T, S>,
-
-    /// For `size_hint()`
-    upper_bound: usize,
 }
 
-impl<'a, T: fmt::Debug> fmt::Debug for Difference<'a, T> {
+impl<'a, T: fmt::Debug> fmt::Debug for Subtract<'a, T> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("Difference")
+        fmt.debug_struct("Subtract")
             .field("items", &self.items)
             .field("other", &self.other)
             .finish()
     }
 }
 
-impl<'a, T, S> Iterator for Difference<'a, T, S>
+impl<'a, T, S> Iterator for Subtract<'a, T, S>
 where
     T: Eq + Hash,
     S: BuildHasher,
@@ -1177,7 +1173,7 @@ where
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (0, Some(self.upper_bound))
+        self.items.size_hint()
     }
 }
 
@@ -1215,61 +1211,72 @@ mod tests {
     }
 
     #[test]
-    fn test_difference_debug_and_size_hint() {
+    fn test_subtract_debug_and_size_hint() {
         let vikings: HashBag<&'static str> = ["Einar", "Olaf", "Harald"].iter().cloned().collect();
         let killed_vikings: HashBag<&'static str> = ["Einar"].iter().cloned().collect();
-        let alive_vikings = vikings.difference(&killed_vikings);
+        let mut alive_vikings = vikings.subtract(&killed_vikings);
         println!("{:?}", alive_vikings);
-        assert_eq!(alive_vikings.size_hint(), (0, Some(3)));
+
+        assert_eq!(alive_vikings.size_hint(), (3, Some(3)));
+
+        // Note that we can't assume in what order the vikings will come, only
+        // that there shall be Some(_) viking two times
+        alive_vikings.next().unwrap();
+        alive_vikings.next().unwrap();
+        assert_eq!(alive_vikings.next(), None);
+
+        // At this point we know that the size hint shall be able to say that
+        // there are no more items
+        assert_eq!(alive_vikings.size_hint(), (0, Some(0)));
     }
 
     #[test]
-    fn test_difference_from_empty() {
-        do_test_difference(&[], &[], &[]);
-        do_test_difference(&[], &[1], &[]);
-        do_test_difference(&[], &[1, 1], &[]);
-        do_test_difference(&[], &[1, 1, 2], &[]);
+    fn test_subtract_from_empty() {
+        do_test_subtract(&[], &[], &[]);
+        do_test_subtract(&[], &[1], &[]);
+        do_test_subtract(&[], &[1, 1], &[]);
+        do_test_subtract(&[], &[1, 1, 2], &[]);
     }
 
     #[test]
-    fn test_difference_from_one() {
-        do_test_difference(&[1], &[], &[1]);
-        do_test_difference(&[1], &[1], &[]);
-        do_test_difference(&[1], &[1, 1], &[]);
-        do_test_difference(&[1], &[2], &[1]);
-        do_test_difference(&[1], &[1, 2], &[]);
-        do_test_difference(&[1], &[2, 2], &[1]);
+    fn test_subtract_from_one() {
+        do_test_subtract(&[1], &[], &[1]);
+        do_test_subtract(&[1], &[1], &[]);
+        do_test_subtract(&[1], &[1, 1], &[]);
+        do_test_subtract(&[1], &[2], &[1]);
+        do_test_subtract(&[1], &[1, 2], &[]);
+        do_test_subtract(&[1], &[2, 2], &[1]);
     }
 
     #[test]
-    fn test_difference_from_duplicate_ones() {
-        do_test_difference(&[1, 1], &[], &[1, 1]);
-        do_test_difference(&[1, 1], &[1], &[1]);
-        do_test_difference(&[1, 1], &[1, 1], &[]);
-        do_test_difference(&[1, 1], &[2], &[1, 1]);
-        do_test_difference(&[1, 1], &[1, 2], &[1]);
-        do_test_difference(&[1, 1], &[2, 2], &[1, 1]);
+    fn test_subtract_from_duplicate_ones() {
+        do_test_subtract(&[1, 1], &[], &[1, 1]);
+        do_test_subtract(&[1, 1], &[1], &[1]);
+        do_test_subtract(&[1, 1], &[1, 1], &[]);
+        do_test_subtract(&[1, 1], &[2], &[1, 1]);
+        do_test_subtract(&[1, 1], &[1, 2], &[1]);
+        do_test_subtract(&[1, 1], &[2, 2], &[1, 1]);
     }
 
     #[test]
-    fn test_difference_from_one_one_two() {
-        do_test_difference(&[1, 1, 2], &[], &[1, 1, 2]);
-        do_test_difference(&[1, 1, 2], &[1], &[1, 2]);
-        do_test_difference(&[1, 1, 2], &[1, 1], &[2]);
-        do_test_difference(&[1, 1, 2], &[2], &[1, 1]);
-        do_test_difference(&[1, 1, 2], &[1, 2], &[1]);
-        do_test_difference(&[1, 1, 2], &[2, 2], &[1, 1]);
+    fn test_subtract_from_one_one_two() {
+        do_test_subtract(&[1, 1, 2], &[], &[1, 1, 2]);
+        do_test_subtract(&[1, 1, 2], &[1], &[1, 2]);
+        do_test_subtract(&[1, 1, 2], &[1, 1], &[2]);
+        do_test_subtract(&[1, 1, 2], &[2], &[1, 1]);
+        do_test_subtract(&[1, 1, 2], &[1, 2], &[1]);
+        do_test_subtract(&[1, 1, 2], &[2, 2], &[1, 1]);
     }
 
     #[test]
-    fn test_difference_from_larger_bags() {
-        do_test_difference(&[1, 2, 2, 3], &[3], &[1, 2, 2]);
-        do_test_difference(&[1, 2, 2, 3], &[4], &[1, 2, 2, 3]);
-        do_test_difference(&[2, 2, 2, 2], &[2, 2], &[2, 2]);
-        do_test_difference(&[2, 2, 2, 2], &[], &[2, 2, 2, 2]);
+    fn test_subtract_from_larger_bags() {
+        do_test_subtract(&[1, 2, 2, 3], &[3], &[1, 2, 2]);
+        do_test_subtract(&[1, 2, 2, 3], &[4], &[1, 2, 2, 3]);
+        do_test_subtract(&[2, 2, 2, 2], &[2, 2], &[2, 2]);
+        do_test_subtract(&[2, 2, 2, 2], &[], &[2, 2, 2, 2]);
     }
 
-    fn do_test_difference(
+    fn do_test_subtract(
         self_entries: &[isize],
         other_entries: &[isize],
         expected_entries: &[isize],
@@ -1278,7 +1285,7 @@ mod tests {
         let other = other_entries.iter().collect::<HashBag<_>>();
         let expected = expected_entries.iter().collect::<HashBag<_>>();
         let mut actual = HashBag::new();
-        for (t, n) in this.difference(&other) {
+        for (t, n) in this.subtract(&other) {
             actual.insert_many(*t, n);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -716,11 +716,11 @@ where
     /// let a: HashBag<_> = [1, 2, 3, 3].iter().cloned().collect();
     /// let b: HashBag<_> = [2, 3].iter().cloned().collect();
     /// let expected: HashSet<_> = HashSet::from_iter([(&1, 1), (&3, 1)]);
-    /// let actual: HashSet<_> = a.subtract(&b).collect();
+    /// let actual: HashSet<_> = a.difference(&b).collect();
     /// assert_eq!(expected, actual);
     /// ```
-    pub fn subtract<'a>(&'a self, other: &'a HashBag<T, S>) -> Subtract<'a, T, S> {
-        Subtract {
+    pub fn difference<'a>(&'a self, other: &'a HashBag<T, S>) -> Difference<'a, T, S> {
+        Difference {
             items: self.items.iter(),
             other,
         }
@@ -1134,9 +1134,9 @@ impl<'a, T> Iterator for Drain<'a, T> {
     }
 }
 
-/// This `struct` is created by [`HashBag::subtract`].
+/// This `struct` is created by [`HashBag::difference`].
 /// See its documentation for more.
-pub struct Subtract<'a, T, S = RandomState> {
+pub struct Difference<'a, T, S = RandomState> {
     /// An iterator over `self` items
     items: IterInner<'a, T>,
 
@@ -1144,16 +1144,16 @@ pub struct Subtract<'a, T, S = RandomState> {
     other: &'a HashBag<T, S>,
 }
 
-impl<'a, T: fmt::Debug> fmt::Debug for Subtract<'a, T> {
+impl<'a, T: fmt::Debug> fmt::Debug for Difference<'a, T> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("Subtract")
+        fmt.debug_struct("Difference")
             .field("items", &self.items)
             .field("other", &self.other)
             .finish()
     }
 }
 
-impl<'a, T, S> Iterator for Subtract<'a, T, S>
+impl<'a, T, S> Iterator for Difference<'a, T, S>
 where
     T: Eq + Hash,
     S: BuildHasher,
@@ -1211,10 +1211,10 @@ mod tests {
     }
 
     #[test]
-    fn test_subtract_debug_and_size_hint() {
+    fn test_difference_debug_and_size_hint() {
         let vikings: HashBag<&'static str> = ["Einar", "Olaf", "Harald"].iter().cloned().collect();
         let killed_vikings: HashBag<&'static str> = ["Einar"].iter().cloned().collect();
-        let mut alive_vikings = vikings.subtract(&killed_vikings);
+        let mut alive_vikings = vikings.difference(&killed_vikings);
         println!("{:?}", alive_vikings);
 
         assert_eq!(alive_vikings.size_hint(), (0, Some(3)));
@@ -1231,52 +1231,52 @@ mod tests {
     }
 
     #[test]
-    fn test_subtract_from_empty() {
-        do_test_subtract(&[], &[], &[]);
-        do_test_subtract(&[], &[1], &[]);
-        do_test_subtract(&[], &[1, 1], &[]);
-        do_test_subtract(&[], &[1, 1, 2], &[]);
+    fn test_difference_from_empty() {
+        do_test_difference(&[], &[], &[]);
+        do_test_difference(&[], &[1], &[]);
+        do_test_difference(&[], &[1, 1], &[]);
+        do_test_difference(&[], &[1, 1, 2], &[]);
     }
 
     #[test]
-    fn test_subtract_from_one() {
-        do_test_subtract(&[1], &[], &[1]);
-        do_test_subtract(&[1], &[1], &[]);
-        do_test_subtract(&[1], &[1, 1], &[]);
-        do_test_subtract(&[1], &[2], &[1]);
-        do_test_subtract(&[1], &[1, 2], &[]);
-        do_test_subtract(&[1], &[2, 2], &[1]);
+    fn test_difference_from_one() {
+        do_test_difference(&[1], &[], &[1]);
+        do_test_difference(&[1], &[1], &[]);
+        do_test_difference(&[1], &[1, 1], &[]);
+        do_test_difference(&[1], &[2], &[1]);
+        do_test_difference(&[1], &[1, 2], &[]);
+        do_test_difference(&[1], &[2, 2], &[1]);
     }
 
     #[test]
-    fn test_subtract_from_duplicate_ones() {
-        do_test_subtract(&[1, 1], &[], &[1, 1]);
-        do_test_subtract(&[1, 1], &[1], &[1]);
-        do_test_subtract(&[1, 1], &[1, 1], &[]);
-        do_test_subtract(&[1, 1], &[2], &[1, 1]);
-        do_test_subtract(&[1, 1], &[1, 2], &[1]);
-        do_test_subtract(&[1, 1], &[2, 2], &[1, 1]);
+    fn test_difference_from_duplicate_ones() {
+        do_test_difference(&[1, 1], &[], &[1, 1]);
+        do_test_difference(&[1, 1], &[1], &[1]);
+        do_test_difference(&[1, 1], &[1, 1], &[]);
+        do_test_difference(&[1, 1], &[2], &[1, 1]);
+        do_test_difference(&[1, 1], &[1, 2], &[1]);
+        do_test_difference(&[1, 1], &[2, 2], &[1, 1]);
     }
 
     #[test]
-    fn test_subtract_from_one_one_two() {
-        do_test_subtract(&[1, 1, 2], &[], &[1, 1, 2]);
-        do_test_subtract(&[1, 1, 2], &[1], &[1, 2]);
-        do_test_subtract(&[1, 1, 2], &[1, 1], &[2]);
-        do_test_subtract(&[1, 1, 2], &[2], &[1, 1]);
-        do_test_subtract(&[1, 1, 2], &[1, 2], &[1]);
-        do_test_subtract(&[1, 1, 2], &[2, 2], &[1, 1]);
+    fn test_difference_from_one_one_two() {
+        do_test_difference(&[1, 1, 2], &[], &[1, 1, 2]);
+        do_test_difference(&[1, 1, 2], &[1], &[1, 2]);
+        do_test_difference(&[1, 1, 2], &[1, 1], &[2]);
+        do_test_difference(&[1, 1, 2], &[2], &[1, 1]);
+        do_test_difference(&[1, 1, 2], &[1, 2], &[1]);
+        do_test_difference(&[1, 1, 2], &[2, 2], &[1, 1]);
     }
 
     #[test]
-    fn test_subtract_from_larger_bags() {
-        do_test_subtract(&[1, 2, 2, 3], &[3], &[1, 2, 2]);
-        do_test_subtract(&[1, 2, 2, 3], &[4], &[1, 2, 2, 3]);
-        do_test_subtract(&[2, 2, 2, 2], &[2, 2], &[2, 2]);
-        do_test_subtract(&[2, 2, 2, 2], &[], &[2, 2, 2, 2]);
+    fn test_difference_from_larger_bags() {
+        do_test_difference(&[1, 2, 2, 3], &[3], &[1, 2, 2]);
+        do_test_difference(&[1, 2, 2, 3], &[4], &[1, 2, 2, 3]);
+        do_test_difference(&[2, 2, 2, 2], &[2, 2], &[2, 2]);
+        do_test_difference(&[2, 2, 2, 2], &[], &[2, 2, 2, 2]);
     }
 
-    fn do_test_subtract(
+    fn do_test_difference(
         self_entries: &[isize],
         other_entries: &[isize],
         expected_entries: &[isize],
@@ -1285,7 +1285,7 @@ mod tests {
         let other = other_entries.iter().collect::<HashBag<_>>();
         let expected = expected_entries.iter().collect::<HashBag<_>>();
         let mut actual = HashBag::new();
-        for (t, n) in this.subtract(&other) {
+        for (t, n) in this.difference(&other) {
             actual.insert_many(*t, n);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1173,7 +1173,7 @@ where
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.items.size_hint()
+        (0, self.items.size_hint().1)
     }
 }
 
@@ -1217,7 +1217,7 @@ mod tests {
         let mut alive_vikings = vikings.subtract(&killed_vikings);
         println!("{:?}", alive_vikings);
 
-        assert_eq!(alive_vikings.size_hint(), (3, Some(3)));
+        assert_eq!(alive_vikings.size_hint(), (0, Some(3)));
 
         // Note that we can't assume in what order the vikings will come, only
         // that there shall be Some(_) viking two times

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1222,6 +1222,15 @@ mod tests {
     }
 
     #[test]
+    fn test_difference_debug_and_size_hint() {
+        let vikings: HashBag<&'static str> = ["Einar", "Olaf", "Harald"].iter().cloned().collect();
+        let killed_vikings: HashBag<&'static str> = ["Einar"].iter().cloned().collect();
+        let alive_vikings = vikings.difference(&killed_vikings);
+        println!("{:?}", alive_vikings);
+        assert_eq!(alive_vikings.size_hint(), (0, Some(3)));
+    }
+
+    #[test]
     fn test_difference_from_empty() {
         do_test_difference(&[], &[], &[]);
         do_test_difference(&[], &[1], &[]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -702,9 +702,10 @@ where
         }
     }
 
-    /// Returns an iterator that visits all values present in `self` that is not
-    /// present in `other`. Takes the number of occurrences into account in both
-    /// bags.
+    /// Returns an iterator over all the elements that are in `self` with a
+    /// higher occurrence count than in `other`. The count in the returned
+    /// iterator represents how many more of a given element are in `self` than
+    /// `other`.
     ///
     /// # Examples
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1211,23 +1211,31 @@ mod tests {
     }
 
     #[test]
-    fn test_difference_debug_and_size_hint() {
+    fn test_difference_debug() {
         let vikings: HashBag<&'static str> = ["Einar", "Olaf", "Harald"].iter().cloned().collect();
         let killed_vikings: HashBag<&'static str> = ["Einar"].iter().cloned().collect();
-        let mut alive_vikings = vikings.difference(&killed_vikings);
+        let alive_vikings = vikings.difference(&killed_vikings);
         println!("{:?}", alive_vikings);
+    }
 
-        assert_eq!(alive_vikings.size_hint(), (0, Some(3)));
+    #[test]
+    fn test_difference_size_hint() {
+        let bag: HashBag<_> = [3, 2, 1].iter().cloned().collect();
+        let empty_bag = HashBag::new();
+        let mut difference = bag.difference(&empty_bag);
 
-        // Note that we can't assume in what order the vikings will come, only
-        // that there shall be Some(_) viking two times
-        alive_vikings.next().unwrap();
-        alive_vikings.next().unwrap();
-        assert_eq!(alive_vikings.next(), None);
-
-        // At this point we know that the size hint shall be able to say that
-        // there are no more items
-        assert_eq!(alive_vikings.size_hint(), (0, Some(0)));
+        // Since the difference has the same number of entries as the bag, we
+        // can predict how the size_hint() will behave, because the iteration
+        // order does not matter
+        assert_eq!(difference.size_hint(), (0, Some(3)));
+        difference.next().unwrap();
+        assert_eq!(difference.size_hint(), (0, Some(2)));
+        difference.next().unwrap();
+        assert_eq!(difference.size_hint(), (0, Some(1)));
+        difference.next().unwrap();
+        assert_eq!(difference.size_hint(), (0, Some(0)));
+        assert_eq!(difference.next(), None);
+        assert_eq!(difference.size_hint(), (0, Some(0)));
     }
 
     #[test]


### PR DESCRIPTION
This corresponds to [`HashSet::difference()`](https://doc.rust-lang.org/std/collections/hash_set/struct.HashSet.html#method.difference), and has the same semantics, and is implemented in a similar manner.

This PR has the following impact on the public API of `hashbag`:

```
% cargo install cargo-public-api
% cargo public-api --diff-git-checkouts origin/master implement-difference
Removed items from the public API
=================================
(none)

Changed items in the public API
===============================
(none)

Added items to the public API
=============================
+pub fn hashbag::Difference::fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result
+pub fn hashbag::Difference::next(&mut self) -> Option<&'a T>
+pub fn hashbag::Difference::size_hint(&self) -> (usize, Option<usize>)
+pub fn hashbag::HashBag::difference<'a>(&'a self, other: &'a HashBag<T, S>) -> Difference<'a, T, S>
+pub struct hashbag::Difference<'a, T, S>
+pub type hashbag::Difference::Item = &'a T
```
