### PR TITLE
Implement outer join and friends

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -759,6 +759,26 @@ where
             .map(|(x, self_count, other_count)| (x, self_count - other_count))
     }
 
+    /// Returns an iterator over all of the elements that are in `self` but not in `other`.
+    ///
+    /// # Examples
+    /// ```
+    /// use hashbag::HashBag;
+    /// use std::collections::HashSet;
+    /// use std::iter::FromIterator;
+    ///
+    /// let a: HashBag<_> = [1, 2, 3, 3].iter().cloned().collect();
+    /// let b: HashBag<_> = [2, 3].iter().cloned().collect();
+    /// let expected: HashSet<_> = HashSet::from_iter([(&1, 1)]);
+    /// let actual: HashSet<_> = a.not_in(&b).collect();
+    /// assert_eq!(expected, actual);
+    /// ```
+    pub fn not_in<'a>(&'a self, other: &'a HashBag<T, S>) -> impl Iterator<Item = (&'a T, usize)> {
+        self.outer_join(&other)
+            .take_while(|(_, self_count, _)| self_count > &0)
+            .filter_map(|(k, self_count, other_count)| (other_count == 0).then(|| (k, self_count)))
+    }
+
     /// Removes a value that is equal to the given one, and returns it if it was the last.
     ///
     /// If the matching value is not the last, a reference to the remainder is given, along with

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -759,6 +759,34 @@ where
             .map(|(x, self_count, other_count)| (x, self_count - other_count))
     }
 
+    /// Returns an iterator over all the elements that are in `self` or `other`.
+    /// The iterator also yields the difference in counts between `self` and `other`.
+    ///
+    /// Unlike 'difference' which only yields elements that have a higher count in `self` than in `other`,
+    /// this iterator yields all elements that are in either of the `HashBag`s. Elements that have a higher
+    /// count in `other` than in self (including elements that are not in `self`) will have a negative count.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashbag::HashBag;
+    /// use std::collections::HashSet;
+    /// use std::iter::FromIterator;
+    ///
+    /// let a: HashBag<_> = [1, 2, 3, 3].iter().cloned().collect();
+    /// let b: HashBag<_> = [2, 3, 4, 4].iter().cloned().collect();
+    /// let expected: HashSet<_> = HashSet::from_iter([(&1, 1), (&2, 0), (&3, 1), (&4, -2)]);
+    /// let actual: HashSet<_> = a.signed_difference(&b).collect();
+    /// assert_eq!(expected, actual);
+    /// ```
+    pub fn signed_difference<'a>(
+        &'a self,
+        other: &'a HashBag<T, S>,
+    ) -> impl Iterator<Item = (&'a T, isize)> {
+        self.outer_join(other)
+            .map(|(x, self_count, other_count)| (x, self_count as isize - other_count as isize))
+    }
+
     /// Returns an iterator over all of the elements that are in `self` but not in `other`.
     ///
     /// # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1392,4 +1392,35 @@ mod tests {
                 });
         assert_eq!(expected, actual);
     }
+
+    #[test]
+    fn test_signed_difference_with_empty_self() {
+        do_test_signed_difference(&[], &[1, 2, 2, 3], &[(&1, -1), (&2, -2), (&3, -1)]);
+    }
+
+    #[test]
+    fn test_signed_difference_with_empty_other() {
+        do_test_signed_difference(&[1, 2, 2, 3], &[], &[(&1, 1), (&2, 2), (&3, 1)]);
+    }
+
+    #[test]
+    fn test_signed_difference_with_overlap() {
+        do_test_signed_difference(
+            &[1, 2, 2, 3, 3],
+            &[3, 4, 5, 5],
+            &[(&1, 1), (&2, 2), (&3, 1), (&4, -1), (&5, -2)],
+        );
+    }
+
+    fn do_test_signed_difference(
+        this: &[usize],
+        other: &[usize],
+        expected_entries: &[(&usize, isize)],
+    ) {
+        let this_hashbag: HashBag<_> = this.iter().cloned().collect();
+        let other_hashbag: HashBag<_> = other.iter().cloned().collect();
+        let expected: HashSet<_> = HashSet::from_iter(expected_entries.iter().cloned());
+        let actual: HashSet<_> = this_hashbag.signed_difference(&other_hashbag).collect();
+        assert_eq!(expected, actual);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -753,14 +753,9 @@ where
         &'a self,
         other: &'a HashBag<T, S>,
     ) -> impl Iterator<Item = (&'a T, usize)> {
-        self.items.iter().filter_map(move |(x, &self_count)| {
-            let other_count = other.contains(x);
-            if self_count > other_count {
-                Some((x, self_count - other_count))
-            } else {
-                None
-            }
-        })
+        self.outer_join(&other)
+            .filter(|(_x, self_count, other_count)| self_count > other_count)
+            .map(|(x, self_count, other_count)| (x, self_count - other_count))
     }
 
     /// Removes a value that is equal to the given one, and returns it if it was the last.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1335,4 +1335,31 @@ mod tests {
         let actual: HashSet<_> = this_hashbag.outer_join(&other_hashbag).collect();
         assert_eq!(expected, actual);
     }
+
+    #[test]
+    fn test_not_in_with_empty_self() {
+        let this: HashBag<_> = HashBag::new();
+        let other: HashBag<_> = [1, 2, 3, 3].iter().cloned().collect();
+        let expected = HashSet::new();
+        let actual: HashSet<_> = this.not_in(&other).collect();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_not_in_with_empty_other() {
+        let this: HashBag<_> = [1, 2, 3, 3].iter().cloned().collect();
+        let other: HashBag<_> = HashBag::new();
+        let expected: HashSet<_> = HashSet::from_iter([(&1, 1), (&2, 1), (&3, 2)]);
+        let actual: HashSet<_> = this.not_in(&other).collect();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_not_in_with_overlap() {
+        let this: HashBag<_> = [1, 2, 3, 3].iter().cloned().collect();
+        let other: HashBag<_> = [2, 4].iter().cloned().collect();
+        let expected: HashSet<_> = HashSet::from_iter([(&1, 1), (&3, 2)]);
+        let actual: HashSet<_> = this.not_in(&other).collect();
+        assert_eq!(expected, actual);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1340,7 +1340,7 @@ mod tests {
 
     #[test]
     fn test_outer_join_with_empty_other() {
-        do_test_outer_join(&[], &[1, 2, 2, 3], &[(&1, 0, 1), (&2, 0, 2), (&3, 0, 1)]);
+        do_test_outer_join(&[1, 2, 2, 3], &[], &[(&1, 1, 0), (&2, 2, 0), (&3, 1, 0)]);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -754,6 +754,7 @@ where
         other: &'a HashBag<T, S>,
     ) -> impl Iterator<Item = (&'a T, usize)> {
         self.outer_join(&other)
+            .take_while(|(_, self_count, _)| self_count > &0)
             .filter(|(_x, self_count, other_count)| self_count > other_count)
             .map(|(x, self_count, other_count)| (x, self_count - other_count))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1338,28 +1338,30 @@ mod tests {
 
     #[test]
     fn test_not_in_with_empty_self() {
-        let this: HashBag<_> = HashBag::new();
-        let other: HashBag<_> = [1, 2, 3, 3].iter().cloned().collect();
-        let expected = HashSet::new();
-        let actual: HashSet<_> = this.not_in(&other).collect();
-        assert_eq!(expected, actual);
+        do_test_not_in(&[], &[1, 2, 3, 3], &[]);
     }
 
     #[test]
     fn test_not_in_with_empty_other() {
-        let this: HashBag<_> = [1, 2, 3, 3].iter().cloned().collect();
-        let other: HashBag<_> = HashBag::new();
-        let expected: HashSet<_> = HashSet::from_iter([(&1, 1), (&2, 1), (&3, 2)]);
-        let actual: HashSet<_> = this.not_in(&other).collect();
-        assert_eq!(expected, actual);
+        do_test_not_in(&[1, 2, 3, 3], &[], &[1, 2, 3, 3]);
     }
 
     #[test]
     fn test_not_in_with_overlap() {
-        let this: HashBag<_> = [1, 2, 3, 3].iter().cloned().collect();
-        let other: HashBag<_> = [2, 4].iter().cloned().collect();
-        let expected: HashSet<_> = HashSet::from_iter([(&1, 1), (&3, 2)]);
-        let actual: HashSet<_> = this.not_in(&other).collect();
+        do_test_not_in(&[1, 2, 3, 3], &[2, 4], &[1, 3, 3]);
+    }
+
+    fn do_test_not_in(this: &[usize], other: &[usize], expected_entries: &[usize]) {
+        let this_hashbag: HashBag<_> = this.iter().cloned().collect();
+        let other_hashbag: HashBag<_> = other.iter().cloned().collect();
+        let expected: HashBag<_> = expected_entries.iter().cloned().collect();
+        let actual: HashBag<_> =
+            this_hashbag
+                .not_in(&other_hashbag)
+                .fold(HashBag::new(), |mut bag, (k, count)| {
+                    bag.insert_many(*k, count);
+                    bag
+                });
         assert_eq!(expected, actual);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -727,7 +727,11 @@ where
             .map(move |(x, &self_count)| (x, self_count, other.contains(x)))
             .chain(other.items.iter().filter_map(move |(x, &other_count)| {
                 let self_count = self.contains(x);
-                (self_count == 0).then(|| (x, self_count, other_count))
+                if self_count == 0 {
+                    Some((x, self_count, other_count))
+                } else {
+                    None
+                }
             }))
     }
 
@@ -804,7 +808,13 @@ where
     pub fn not_in<'a>(&'a self, other: &'a HashBag<T, S>) -> impl Iterator<Item = (&'a T, usize)> {
         self.outer_join(other)
             .take_while(|(_, self_count, _)| self_count > &0)
-            .filter_map(|(k, self_count, other_count)| (other_count == 0).then(|| (k, self_count)))
+            .filter_map(|(k, self_count, other_count)| {
+                if other_count == 0 {
+                    Some((k, self_count))
+                } else {
+                    None
+                }
+            })
     }
 
     /// Removes a value that is equal to the given one, and returns it if it was the last.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -753,7 +753,7 @@ where
         &'a self,
         other: &'a HashBag<T, S>,
     ) -> impl Iterator<Item = (&'a T, usize)> {
-        self.outer_join(&other)
+        self.outer_join(other)
             .take_while(|(_, self_count, _)| self_count > &0)
             .filter(|(_x, self_count, other_count)| self_count > other_count)
             .map(|(x, self_count, other_count)| (x, self_count - other_count))
@@ -802,7 +802,7 @@ where
     /// assert_eq!(expected, actual);
     /// ```
     pub fn not_in<'a>(&'a self, other: &'a HashBag<T, S>) -> impl Iterator<Item = (&'a T, usize)> {
-        self.outer_join(&other)
+        self.outer_join(other)
             .take_while(|(_, self_count, _)| self_count > &0)
             .filter_map(|(k, self_count, other_count)| (other_count == 0).then(|| (k, self_count)))
     }


### PR DESCRIPTION
This PR implements all of the methods described [this comment](https://github.com/jonhoo/hashbag/pull/6#issuecomment-1162596000) on #6 :
- `outer_join`: Takes in a reference to a second `HashBag` and returns an iterator that yields the union of the key sets for both `HashBag`s (ie. `keyset(self) ∪ keyset(other)`). Each key is yielded along with its corresponding counts on each `HashBag`.
  - The rest of the functions added in this PR as well as `difference` introduced in #6 can be implemented using this function
- `not_in`: Takes in a reference to a second `HashBag` and returns an iterator that yields the set difference between the key set of the first `HashBag` and the second one (i.e. `keyset(self) \ keyset(other)`). Each key is yielded along with its corresponding count on the first `HashBag`.
- `signed_difference`: Takes in a reference to a second `HashBag` and returns an iterator that yields the union of the keys sets for both `HashBag`s (ie. `keyset(self) ∪ keyset(other`). Each key is yielded along with the difference between its count on the first and second `HashBag`s.