### PR TITLE
Clamp isize values returned by `signed_difference`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -801,26 +801,25 @@ where
     where
         OtherS: BuildHasher,
     {
-        self.outer_join(other)
-            .map(|(x, self_count, other_count)| {
-                if self_count >= other_count {
-                    let diff = self_count - other_count;
-                    let diff = if diff >= std::isize::MAX as usize {
-                        isize::MAX
-                    } else {
-                        diff as isize
-                    };
-                    (x, diff)
+        self.outer_join(other).map(|(x, self_count, other_count)| {
+            if self_count >= other_count {
+                let diff = self_count - other_count;
+                let diff = if diff >= std::isize::MAX as usize {
+                    isize::MAX
                 } else {
-                    let diff = other_count - self_count;
-                    let diff = if diff >= std::isize::MIN as usize {
-                        isize::MIN
-                    } else {
-                        -(diff as isize)
-                    };
-                    (x, diff)
-                }
-            })
+                    diff as isize
+                };
+                (x, diff)
+            } else {
+                let diff = other_count - self_count;
+                let diff = if diff >= std::isize::MIN as usize {
+                    isize::MIN
+                } else {
+                    -(diff as isize)
+                };
+                (x, diff)
+            }
+        })
     }
 
     /// Returns an iterator over all of the elements that are in `self` but not in `other`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -805,7 +805,7 @@ where
             .map(|(x, self_count, other_count)| {
                 if self_count >= other_count {
                     let diff = self_count - other_count;
-                    let diff = if diff >= isize::MAX as usize {
+                    let diff = if diff >= std::isize::MAX as usize {
                         isize::MAX
                     } else {
                         diff as isize
@@ -813,7 +813,7 @@ where
                     (x, diff)
                 } else {
                     let diff = other_count - self_count;
-                    let diff = if diff >= isize::MIN as usize {
+                    let diff = if diff >= std::isize::MIN as usize {
                         isize::MIN
                     } else {
                         -(diff as isize)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -794,26 +794,6 @@ where
     /// let actual: HashSet<_> = a.signed_difference(&b).collect();
     /// assert_eq!(expected, actual);
     /// ```
-    ///
-    /// ```
-    /// # use hashbag::HashBag;
-    /// # use std::collections::HashSet;
-    /// # use std::iter::FromIterator;
-    /// let mut a: HashBag<_> = HashBag::new();
-    /// let mut b: HashBag<_> = HashBag::new();
-    /// let large_count = isize::MIN as usize;
-    /// a.insert_many(1, large_count);
-    /// b.insert_many(1, 3);
-    /// let expected: HashSet<_> = HashSet::from_iter([(&1, (large_count - 3) as isize)]);
-    /// let actual: HashSet<_> = a.signed_difference(&b).collect();
-    /// assert_eq!(expected, actual);
-    ///
-    /// // Add more elements to `a`, the difference won't fit in an `isize`.
-    /// a.insert_many(1, 1000);
-    /// let expected: HashSet<_> = HashSet::from_iter([(&1, isize::MAX)]);
-    /// let actual: HashSet<_> = a.signed_difference(&b).collect();
-    /// assert_eq!(expected, actual);
-    /// ```
     pub fn signed_difference<'a, OtherS>(
         &'a self,
         other: &'a HashBag<T, OtherS>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -805,7 +805,7 @@ where
             if self_count >= other_count {
                 let diff = self_count - other_count;
                 let diff = if diff >= std::isize::MAX as usize {
-                    isize::MAX
+                    std::isize::MAX
                 } else {
                     diff as isize
                 };
@@ -813,7 +813,7 @@ where
             } else {
                 let diff = other_count - self_count;
                 let diff = if diff >= std::isize::MIN as usize {
-                    isize::MIN
+                    std::isize::MIN
                 } else {
                     -(diff as isize)
                 };
@@ -1494,7 +1494,7 @@ mod tests {
         let mut this_hashbag = HashBag::new();
         let mut other_hashbag = HashBag::new();
 
-        let large_count = isize::MAX as usize;
+        let large_count = std::isize::MAX as usize;
         this_hashbag.insert_many(1, large_count + 1000);
         other_hashbag.insert_many(1, large_count);
 
@@ -1513,15 +1513,15 @@ mod tests {
         let mut this_hashbag = HashBag::new();
         let empty_hashbag = HashBag::new();
 
-        let large_count = isize::MAX as usize;
+        let large_count = std::isize::MAX as usize;
         this_hashbag.insert_many(1, large_count + 1000);
 
-        let expected: HashSet<_> = HashSet::from_iter([(&1, isize::MAX)].iter().cloned());
+        let expected: HashSet<_> = HashSet::from_iter([(&1, std::isize::MAX)].iter().cloned());
         let actual: HashSet<_> = this_hashbag.signed_difference(&empty_hashbag).collect();
         assert_eq!(expected, actual);
 
         // and in reverse:
-        let expected: HashSet<_> = HashSet::from_iter([(&1, isize::MIN)].iter().cloned());
+        let expected: HashSet<_> = HashSet::from_iter([(&1, std::isize::MIN)].iter().cloned());
         let actual: HashSet<_> = empty_hashbag.signed_difference(&this_hashbag).collect();
         assert_eq!(expected, actual);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -803,15 +803,14 @@ where
         OtherS: BuildHasher,
     {
         self.outer_join(other).map(|(x, self_count, other_count)| {
-            if self_count >= other_count {
-                let diff = isize::try_from(self_count - other_count).unwrap_or(std::isize::MAX);
-                (x, diff)
+            let diff = if self_count >= other_count {
+                isize::try_from(self_count - other_count).unwrap_or(std::isize::MAX)
             } else {
-                let diff = isize::try_from(other_count - self_count)
+                isize::try_from(other_count - self_count)
                     .map(|x| -x)
-                    .unwrap_or(std::isize::MIN);
-                (x, diff)
-            }
+                    .unwrap_or(std::isize::MIN)
+            };
+            (x, diff)
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1510,6 +1510,43 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_signed_difference_with_both_large() {
+        let mut this_hashbag = HashBag::new();
+        let mut other_hashbag = HashBag::new();
+
+        let large_count = isize::MAX as usize;
+        this_hashbag.insert_many(1, large_count + 1000);
+        other_hashbag.insert_many(1, large_count);
+
+        let expected: HashSet<_> = HashSet::from_iter([(&1, 1000)].iter().cloned());
+        let actual: HashSet<_> = this_hashbag.signed_difference(&other_hashbag).collect();
+        assert_eq!(expected, actual);
+
+        // and in reverse:
+        let expected: HashSet<_> = HashSet::from_iter([(&1, -1000)].iter().cloned());
+        let actual: HashSet<_> = other_hashbag.signed_difference(&this_hashbag).collect();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_signed_difference_too_large_to_hold_clamp() {
+        let mut this_hashbag = HashBag::new();
+        let empty_hashbag = HashBag::new();
+
+        let large_count = isize::MAX as usize;
+        this_hashbag.insert_many(1, large_count + 1000);
+
+        let expected: HashSet<_> = HashSet::from_iter([(&1, isize::MAX)].iter().cloned());
+        let actual: HashSet<_> = this_hashbag.signed_difference(&empty_hashbag).collect();
+        assert_eq!(expected, actual);
+
+        // and in reverse:
+        let expected: HashSet<_> = HashSet::from_iter([(&1, isize::MIN)].iter().cloned());
+        let actual: HashSet<_> = empty_hashbag.signed_difference(&this_hashbag).collect();
+        assert_eq!(expected, actual);
+    }
+
     fn do_test_signed_difference(
         this: &[usize],
         other: &[usize],


### PR DESCRIPTION
Since the difference of two usizes may not fit in an isize, clamp the
values to isize::MIN/MAX when the difference cannot be represented.

Also, be careful to avoid subtracting with overflow when computing the
diff

I couldn't think of a more succinct way to perform a clamping difference,
I'd be happy if there's a way to do it cleaner.