### PR TITLE
Ergonomics Improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,11 @@ categories = ["data-structures"]
 
 [dependencies]
 griddle = { version = "0.5", optional = true }
-serde = { version = "1.0", features = ["derive"], optional = true }
+serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 serde_json = { version = "1.0" }
+serde = { version = "1.0", features = ["derive"] }
 
 [features]
 amortize = ["griddle"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -744,72 +744,27 @@ where
     ///
     /// bag.insert_many('x', 10);
     /// assert_eq!(bag.contains(&'x'), 10);
-    /// assert_eq!(bag.remove_many(&'x', 3), 7);
+    /// assert_eq!(bag.remove_up_to(&'x', 3), 7);
     /// assert_eq!(bag.contains(&'x'), 7);
-    /// assert_eq!(bag.remove_many(&'x', 10), 0);
+    /// assert_eq!(bag.remove_up_to(&'x', 10), 0);
     /// ```
     #[inline]
-    pub fn remove_many<Q: ?Sized>(&mut self, value: &Q, quantity: usize) -> usize
+    pub fn remove_up_to<Q: ?Sized>(&mut self, value: &Q, quantity: usize) -> usize
     where
         T: Borrow<Q>,
         Q: Hash + Eq,
     {
         match self.items.get_mut(value) {
             None => 0,
-            Some(n) if *n <= quantity => {
-                self.count -= 1;
+            Some(&mut n) if n <= quantity => {
+                self.count -= n;
                 self.items.remove(value);
                 0
             }
             Some(n) => {
+                self.count -= quantity;
                 *n -= quantity;
                 *n
-            }
-        }
-    }
-
-    /// Removes multiple of a value from the bag. If `quantity` is greater than the number of
-    /// occurences, then the value is unchanged
-    ///
-    /// If the value is changed, the number of occurrences of the value currently in the bag is
-    /// returned.
-    ///
-    /// The value may be any borrowed form of the bag's value type, but
-    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
-    /// the value type.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use hashbag::HashBag;
-    ///
-    /// let mut bag = HashBag::new();
-    ///
-    /// bag.insert_many('x', 10);
-    /// assert_eq!(bag.contains(&'x'), 10);
-    /// assert_eq!(bag.remove_many_checked(&'x', 3), Some(7));
-    /// assert_eq!(bag.contains(&'x'), 7);
-    /// assert_eq!(bag.remove_many_checked(&'x', 10), None);
-    /// assert_eq!(bag.contains(&'x'), 7);
-    /// assert_eq!(bag.remove_many_checked(&'x', 7), Some(0));
-    /// ```
-    #[inline]
-    pub fn remove_many_checked<Q: ?Sized>(&mut self, value: &Q, quantity: usize) -> Option<usize>
-    where
-        T: Borrow<Q>,
-        Q: Hash + Eq,
-    {
-        match self.items.get_mut(value) {
-            None => Some(0),
-            Some(n) if *n < quantity => None,
-            Some(n) if *n == quantity => {
-                self.count -= 1;
-                self.items.remove(value);
-                Some(0)
-            }
-            Some(n) => {
-                *n -= quantity;
-                Some(*n)
             }
         }
     }
@@ -1701,5 +1656,19 @@ mod tests {
         assert_eq!(hashbag.iter().count(), 0);
         assert_eq!(hashbag.set_len(), 0);
         assert_eq!(hashbag.set_iter().count(), 0);
+    }
+
+    #[test]
+    fn remove_up_to_affects_count() {
+        let mut bag = HashBag::new();
+        // Standard behavior
+        bag.insert_many(42, 3);
+        assert_eq!(bag.len(), 3);
+        assert_eq!(bag.remove_up_to(&0, 1), 0);
+        assert_eq!(bag.len(), 3);
+        assert_eq!(bag.remove_up_to(&42, 1), 2);
+        assert_eq!(bag.len(), 2);
+        assert_eq!(bag.remove_up_to(&42, 10), 0);
+        assert_eq!(bag.len(), 0);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1173,9 +1173,7 @@ pub(crate) mod entry {
 
     impl<'a, T, S> ForiegnEntry<'a, T, S> {
         pub(crate) fn new(entry: Entry<'a, T, usize, S>) -> Self {
-            Self {
-                entry,
-            }
+            Self { entry }
         }
 
         pub(crate) fn get_mut(&mut self) -> Option<&mut usize> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -580,22 +580,20 @@ where
             .map(|(t, count)| (t, *count))
     }
 
-    /// Returns a reference to the value in the bag, if any, that is equal to the given value,
-    /// along with its number of occurrences.
-    ///
-    /// The value may be any borrowed form of the bag's value type, but
-    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
-    /// the value type.
+    /// Gets a given value's corresponding entry in the bag for in-place manipulation.
     ///
     /// # Examples
     ///
     /// ```
     /// use hashbag::HashBag;
     ///
-    /// let bag: HashBag<_> = [1, 2, 3, 3].iter().cloned().collect();
-    /// assert_eq!(bag.get(&2), Some((&2, 1)));
-    /// assert_eq!(bag.get(&3), Some((&3, 2)));
-    /// assert_eq!(bag.get(&4), None);
+    /// let mut bag: HashBag<char> = ['a'].iter().cloned().collect();
+    /// let entry = bag.entry('a').and_modify(|n| *n += 1).or_insert();
+    /// assert_eq!(bag.get(&'a'), Some((&'a', 2)));
+    /// let entry = bag.entry('b').and_modify(|n| *n += 1).or_insert();
+    /// assert_eq!(bag.get(&'b'), Some((&'b', 1)));
+    /// let entry = bag.entry('c').and_modify(|n| *n += 1).or_insert_many(7);
+    /// assert_eq!(bag.get(&'c'), Some((&'c', 7)));
     /// ```
     #[inline]
     pub fn entry(&mut self, value: T) -> Entry<'_, T, S> {
@@ -1196,7 +1194,10 @@ impl<T, S> IntoIterator for HashBag<T, S> {
 #[cfg(feature = "amortize")]
 type EntryInner<'a, T, S> = (griddle::hash_map::Entry<'a, T, usize, S>, PhantomData<S>);
 #[cfg(not(feature = "amortize"))]
-type EntryInner<'a, T, S> = (std::collections::hash_map::Entry<'a, T, usize>, PhantomData<S>);
+type EntryInner<'a, T, S> = (
+    std::collections::hash_map::Entry<'a, T, usize>,
+    PhantomData<S>,
+);
 
 #[derive(Debug)]
 /// A view into a single entry in the bag, which may either be vacant or occupied.
@@ -1204,33 +1205,34 @@ type EntryInner<'a, T, S> = (std::collections::hash_map::Entry<'a, T, usize>, Ph
 pub struct Entry<'a, T, S>(EntryInner<'a, T, S>);
 
 impl<'a, T, S> Entry<'a, T, S>
-where 
+where
     T: Hash + Eq,
-    S: BuildHasher
+    S: BuildHasher,
 {
     /// Provides in-place mutable access to an occupied entry before potential inserts into the
     /// map.
     pub fn and_modify<F>(self, f: F) -> Self
-        where F: FnOnce(&mut usize),
+    where
+        F: FnOnce(&mut usize),
     {
-        Self((self.0.0.and_modify(f), PhantomData))
+        Self((self.0 .0.and_modify(f), PhantomData))
     }
-    
+
     /// Returns a reference to the entry's value.
     pub fn value(&self) -> &T {
-        self.0.0.key()
+        self.0 .0.key()
     }
-    
+
     /// Ensures there is at least one instance of the value before returning a mutable reference
     /// to the value's count
     pub fn or_insert(self) -> &'a mut usize {
-        self.0.0.or_insert(1)
+        self.0 .0.or_insert(1)
     }
-    
+
     /// Ensures there is at least `quantity` instances of the value before returning a mutable reference
     /// to the value's count
     pub fn or_insert_many(self, quantity: usize) -> &'a mut usize {
-        self.0.0.or_insert(quantity)
+        self.0 .0.or_insert(quantity)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -706,6 +706,94 @@ where
         }
     }
 
+    /// Removes multiple of a value from the bag. If `quantity` is greater than the number of
+    /// occurences, zero occurances will remain.
+    ///
+    /// The number of occurrences of the value currently in the bag is returned.
+    ///
+    /// The value may be any borrowed form of the bag's value type, but
+    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
+    /// the value type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashbag::HashBag;
+    ///
+    /// let mut bag = HashBag::new();
+    ///
+    /// bag.insert_many('x', 10);
+    /// assert_eq!(bag.contains(&'x'), 10);
+    /// assert_eq!(bag.remove_many(&'x', 3), 7);
+    /// assert_eq!(bag.contains(&'x'), 7);
+    /// assert_eq!(bag.remove_many(&'x', 10), 0);
+    /// ```
+    #[inline]
+    pub fn remove_many<Q: ?Sized>(&mut self, value: &Q, quantity: usize) -> usize
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        match self.items.get_mut(value) {
+            None => 0,
+            Some(n) if *n <= quantity => {
+                self.count -= 1;
+                self.items.remove(value);
+                0
+            }
+            Some(n) => {
+                *n -= quantity;
+                *n
+            }
+        }
+    }
+
+    /// Removes multiple of a value from the bag. If `quantity` is greater than the number of
+    /// occurences, then the value is unchanged
+    ///
+    /// If the value is changed, the number of occurrences of the value currently in the bag is
+    /// returned.
+    ///
+    /// The value may be any borrowed form of the bag's value type, but
+    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
+    /// the value type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashbag::HashBag;
+    ///
+    /// let mut bag = HashBag::new();
+    ///
+    /// bag.insert_many('x', 10);
+    /// assert_eq!(bag.contains(&'x'), 10);
+    /// assert_eq!(bag.remove_many_checked(&'x', 3), Some(7));
+    /// assert_eq!(bag.contains(&'x'), 7);
+    /// assert_eq!(bag.remove_many_checked(&'x', 10), None);
+    /// assert_eq!(bag.contains(&'x'), 7);
+    /// assert_eq!(bag.remove_many_checked(&'x', 7), Some(0));
+    /// ```
+    #[inline]
+    pub fn remove_many_checked<Q: ?Sized>(&mut self, value: &Q, quantity: usize) -> Option<usize>
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        match self.items.get_mut(value) {
+            None => Some(0),
+            Some(n) if *n < quantity => None,
+            Some(n) if *n == quantity => {
+                self.count -= 1;
+                self.items.remove(value);
+                Some(0)
+            }
+            Some(n) => {
+                *n -= quantity;
+                Some(*n)
+            }
+        }
+    }
+
     /// Returns an iterator over all of the elements that are in `self` or `other`.
     /// The iterator also yields the respective counts in `self` and `other` in that order.
     /// Elements that are in `self` are yielded before any elements that are exclusively in `other`.


### PR DESCRIPTION
## Functional Changes:
Added three new methods to `HashBag`: `remove_many`, `remove_many_checked`, and `entry`.

The first two methods relate to #13. I imagine the default usecase will not care if they attempt to remove too many items. However, I can imagine cases where you do not want to change the bag if you attempt to remove too many items. Hence the two methods.

The last method is a thin wrapper around `entry` method of the underlying map that has been adjusted to make sense in this context.

## Non-functional Changes:
When I added `serde` support, I made a small mistake. The `derive` feature of serde is only needed during testing. The derive feature was removed and added to the `dev-dependencies`.