### PR TITLE
fix `len` in `serialize_seq`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1.0", optional = true }
 [dev-dependencies]
 serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
+bincode = { version = "1.3" }
 
 [features]
 amortize = ["griddle"]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -71,7 +71,7 @@ where
     where
         S: Serializer,
     {
-        let mut bag = serializer.serialize_seq(Some(self.len()))?;
+        let mut bag = serializer.serialize_seq(Some(self.set_len()))?;
 
         for (entry, count) in self.set_iter() {
             bag.serialize_element(&(entry, count))?;
@@ -177,5 +177,26 @@ mod tests {
         assert_eq!(reconstituted_vikings.get(&einar), Some((&einar, 1)));
         assert_eq!(reconstituted_vikings.get(&olaf), Some((&olaf, 2)));
         assert_eq!(reconstituted_vikings.get(&harald), Some((&harald, 3)));
+    }
+
+    #[test]
+    fn serde_bincode() {
+        let vikings: HashBag<String> = ["Einar", "Olaf", "Olaf", "Harald", "Harald", "Harald"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let einar = "Einar".to_string();
+        let olaf = "Olaf".to_string();
+        let harald = "Harald".to_string();
+        assert_eq!(vikings.get(&einar), Some((&einar, 1)));
+        assert_eq!(vikings.get(&olaf), Some((&olaf, 2)));
+        assert_eq!(vikings.get(&harald), Some((&harald, 3)));
+        println!("Constructed: {:?}", vikings);
+        let bincoded_vikings =
+            bincode::serialize(&vikings).expect("Unable to serialize to bincode!");
+        let reconstituted_vikings: HashBag<String> =
+            bincode::deserialize(&bincoded_vikings).expect("Unable to deserialize bincode!");
+        println!("From bincode: {:?}", reconstituted_vikings);
+        assert_eq!(vikings, reconstituted_vikings);
     }
 }


### PR DESCRIPTION
Some serializers (e.g. `bincode` but not `serde_json`) rely on the value `len` passed to `serialize_seq` which must be equal to the number of elements to be serialized. Current implementation serializes pairs (entry, count) but passes `self.len()` (e.g. sum of counts, not the number of entries). I have fixed `len` to be equal to `self.set_len()` and added a test with `bincode` serializer that used to fail.